### PR TITLE
Added TestUser.timer_set_groups()

### DIFF
--- a/padsweb/tests/tests_views.py
+++ b/padsweb/tests/tests_views.py
@@ -174,6 +174,18 @@ class TestUser:
         self.last_response = response
         return response
 
+    def timer_set_groups(self, timer_id, timer_group_names):
+        # Assigns a Timer to Timer Groups specified by name. Groups should be
+        # automatically created if they have not been so. The Timer will also
+        # be removed from unspecified Groups if there are existing inclusions.
+        
+        url_timer_set_groups = reverse(
+                'padsweb:timer_set_groups', kwargs={'timer_id':timer_id})
+        req_body_tg_set = {'group_names' : timer_group_names}
+        response = self.client.post(url_timer_set_groups, req_body_tg_set)
+        self.last_response = response
+        return response
+
     def timer_delete(self, timer_id):
         # Deletes a Timer
         


### PR DESCRIPTION
TestUser.timer_set_groups() enables integration testing with the new set Timer Groups by name feature. This early push is also an attempt to incorporate a correction from the master branch.