### PR TITLE
0.590 refactored views Rewritten Timer Helpers plus User Write Timer Helper unit tests

### DIFF
--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -276,11 +276,18 @@ class PADSWriteTimerHelper(PADSWriteHelper):
     def add_to_group(self, timer_id, group_id):
         if self.user_is_registered() is False:
             return False
+        if (isinstance(timer_id, int) & isinstance(group_id, int) ) is False:
+            return False
         else:
-            timer_exists = self.timer_model.objects.filter(
+            # Note: any user can add any Public Timer to own groups, even
+            #  if they were created/owned by another user
+            public_timer_exists = self.timer_model.objects.filter(
+                    pk=timer_id, public=True).exists()
+            user_timer_exists = self.user_timers.filter(
                     pk=timer_id).exists()
-            group_exists = self.group_model.objects.filter(
+            group_exists = self.user_timer_groups.filter(
                     pk=group_id).exists()
+            timer_exists = public_timer_exists | user_timer_exists
             if (timer_exists is True) & (group_exists is True):
                 group_inclusion = GroupInclusion()
                 group_inclusion.group_id = group_id

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -196,6 +196,10 @@ class PADSReadTimerHelper(PADSReadHelper):
 
 class PADSWriteTimerHelper(PADSWriteHelper):
     def new(self, description, **kwargs):
+        """Creates a new Timer and saves it to the database.
+        Returns the new Timer's id as an int on success. Returns None on 
+        failure.
+        """
         if self.user_is_registered() is False:
             return None
         else:
@@ -217,7 +221,7 @@ class PADSWriteTimerHelper(PADSWriteHelper):
     def new_group(self, name):
         """Creates a new Timer Group and saves it to the database. 
         Returns the new Timer Group's id as an int on success. Returns None
-        on failure, or the id of the new Timer Group on success.
+        on failure.
         """
         if self.user_is_registered() is False:
             return None
@@ -255,7 +259,7 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         
     def add_to_group(self, timer_id, group_id):
         if self.user_is_registered() is False:
-            return None
+            return False
         else:
             timer_exists = self.timer_model.objects.filter(
                     pk=timer_id).exists()
@@ -265,8 +269,10 @@ class PADSWriteTimerHelper(PADSWriteHelper):
                 group_inclusion = GroupInclusion()
                 group_inclusion.group_id = group_id
                 group_inclusion.timer_id = timer_id
+                group_inclusion.save()
+                return True
             else:
-                return None
+                return False
                 
     def remove_from_group(self, timer_id, group_id):
         if self.user_is_registered() is False:

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -260,6 +260,12 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         """
         if self.user_is_registered() is False:
             return None
+        elif isinstance(description, str) is False:
+            return None
+        elif len(description) <= 0:
+            return None
+        elif description.isspace() is True:
+            return None
         else:
             timer_exists = self.user_timers.filter(pk=timer_id).exists()
             if timer_exists is True:

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -385,17 +385,25 @@ class PADSWriteTimerHelper(PADSWriteHelper):
                     return False
         
     def stop_by_id(self, timer_id, reason):
+        stop_time = timezone.now()
         if self.user_is_registered() is False:
             return False        
+        if isinstance(reason, str) is False:
+            return False
+        elif reason.isspace() is True:
+            return False
+        elif (len(reason) <= 0):
+            return False
         else:
-            timer_exists = self.timer_model.objects.filter(
+            timer_exists = self.user_timers.filter(
                     pk=timer_id).exists()
 
         if timer_exists is False:
             return False
         else:
-            timer = self.timer_model.objects.get(pk=timer_id)
+            timer = self.user_timers.get(pk=timer_id)
             timer_historical = timer.historical
+            timer.count_from_date_time = stop_time # Stopping a timer resets it
             timer.running = False
         
             with transaction.atomic():

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -255,8 +255,7 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         if self.user_is_registered() is False:
             return None
         else:
-            timer_exists = self.timer_model.objects.filter(
-                    pk=timer_id).exists()
+            timer_exists = self.user_timers.filter(pk=timer_id).exists()
             if timer_exists is True:
                 log_time = timezone.now()
                 new_log_entry = PADSTimerReset()

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -21,6 +21,15 @@ settings = defaults
 
 class PADSHelper:
     """Base class for other PADS helper classes"""
+    def get_user_from_db(self):
+        if self.user_is_registered():
+            if self.user_model.objects.filter(pk=self.user_id).exists():
+                return self.user_model.objects.get(pk=self.user_id)
+            else:
+                return None
+        else:
+            return None
+    
     def set_user_id(self, user_id):
         """Assigns a Helper to a User id. This is intended to assist access 
         control routines. Only valid User ids may be assigned. If the User is 
@@ -388,13 +397,7 @@ class PADSUserHelper(PADSHelper):
     to the lack of use of the page() and get_by_id() methods. This class is
     meant to only interact with one user account at a time, and the get_by_id()
     method is redundant due to the way this class is used.
-    """
-    def get_user_from_db(self):
-        if self.user_is_registered():
-            return self.user_model.objects.get(pk=self.user_id)
-        else:
-            return None
-    
+    """    
     def get_user_from_db_by_username(self, user_name):
         if isinstance(user_name, str):
             if self.user_model.objects.filter(
@@ -543,15 +546,6 @@ class PADSWriteUserHelper(PADSWriteHelper):
             new_user.save()
             return new_user.nickname_short
 
-        else:
-            return None
-        
-    def get_user_from_db(self):
-        if self.user_is_registered():
-            if self.user_model.objects.filter(pk=self.user_id).exists():
-                return self.user_model.objects.get(pk=self.user_id)
-            else:
-                return None
         else:
             return None
 

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -307,10 +307,13 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         elif isinstance(timer_id, int) is False:
             return False
         else:
-            timer_exists = self.timer_model.objects.filter(
-                    pk=timer_id).exists()
+            # Restrict access of Timers to those created by assigned User
+            # of matching id
+            timers_available = self.timer_model.objects.filter(
+                    creator_user_id=self.user_id) 
+            timer_exists = timers_available.filter(pk=timer_id).exists()
             if timer_exists is True:
-                timer = self.timer_model.objects.get(pk=timer_id)
+                timer = timers_available.get(pk=timer_id)
                 timer.delete()
                 return True
             else:

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -293,18 +293,26 @@ class PADSWriteTimerHelper(PADSWriteHelper):
     def remove_from_group(self, timer_id, group_id):
         if self.user_is_registered() is False:
             return False
+        if (isinstance(timer_id, int) & isinstance(group_id, int) ) is False:
+            return False
         else:
+            group_exists = self.user_timer_groups.filter(
+                    pk=group_id).exists()
+            # Note: any user can remove any timer from own groups
             timer_exists = self.timer_model.objects.filter(
                     pk=timer_id).exists()
-            group_exists = self.group_model.objects.filter(
-                    pk=group_id).exists()
-            if (timer_exists is True) & (group_exists is True):
-                group_inclusion = self.group_incl_model.objects.get(
-                        timer_id=timer_id, group_id=group_id)
-                group_inclusion.delete()
-                return True
-            else:
+            if timer_exists & group_exists is False:
                 return False
+            else:
+                group_incl_exists = self.group_incl_model.objects.filter(
+                        timer_id=timer_id, group_id=group_id).exists()
+                if group_incl_exists is True:
+                    group_incl= self.group_incl_model.objects.get(
+                            timer_id=timer_id, group_id=group_id)
+                    group_incl.delete()                    
+                    return True
+                else:
+                    return False
 
     def delete(self, timer_id):
         if self.user_is_registered() is False:

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -178,7 +178,11 @@ class PADSReadTimerHelper(PADSReadHelper):
         return None
 
     def get_resets_from_db_by_timer_id(self, timer_id):
-        return self.timer_log_model.objects.filter(timer_id=timer_id)    
+        timer_exists = self.get_all_from_db().filter(pk=timer_id).exists()
+        if timer_exists is True:
+            resets = self.timer_log_model.objects.filter(timer_id=timer_id)
+            return resets
+        return None
     
     #
     # Introspection and Constructor Methods
@@ -254,6 +258,7 @@ class PADSWriteTimerHelper(PADSWriteHelper):
             if timer_exists is True:
                 log_time = timezone.now()
                 new_log_entry = PADSTimerReset()
+                new_log_entry.reason = description
                 new_log_entry.timer_id = timer_id
                 new_log_entry.date_time = log_time
                 new_log_entry.save()

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -168,10 +168,14 @@ class PADSReadTimerHelper(PADSReadHelper):
         return self.get_groups_all().filter(name__icontains=name)
 
     def get_groups_by_timer_id(self, timer_id):
-        timer = self.get_all_from_db().get(pk=timer_id, 
-                                    creator_user_id=self.user_id)
-        groups = timer.in_groups.all()
-        return groups
+        timer_exists = self.get_all_from_db().filter(
+                pk=timer_id, creator_user_id=self.user_id).exists()
+        if timer_exists is True:
+            timer = self.get_all_from_db().get(pk=timer_id, 
+                                        creator_user_id=self.user_id)
+            groups = timer.in_groups.all()
+            return groups
+        return None
 
     def get_resets_from_db_by_timer_id(self, timer_id):
         return self.timer_log_model.objects.filter(timer_id=timer_id)    

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -235,8 +235,14 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         """
         if self.user_is_registered() is False:
             return None
+        elif isinstance(name, str) is False:
+            return None
+        elif len(name) <= 0:
+            return None
+        elif name.isspace() is True:
+            return None
         else:
-            group_exists = self.group_model.objects.filter(name=name).exists()
+            group_exists = self.user_timer_groups.filter(name=name).exists()
             if group_exists is True:
                 return None
             else:
@@ -312,6 +318,21 @@ class PADSWriteTimerHelper(PADSWriteHelper):
             if timer_exists is True:
                 timer = self.user_timers.get(pk=timer_id)
                 timer.delete()
+                return True
+            else:
+                return False
+    
+    def delete_group_by_id(self, timer_group_id):
+        if self.user_is_registered() is False:
+            return False
+        elif isinstance(timer_group_id, int) is False:
+            return False
+        else:
+            timer_group_exists = self.user_timer_groups.filter(
+                    pk=timer_group_id).exists()
+            if timer_group_exists is True:
+                timer_group = self.user_timer_groups.get(pk=timer_group_id)
+                timer_group.delete()
                 return True
             else:
                 return False

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -210,19 +210,34 @@ class PADSWriteTimerHelper(PADSWriteHelper):
         """
         if self.user_is_registered() is False:
             return None
+        elif isinstance(description, str) is False:
+            return None
+        elif len(description) <= 0:
+            return None
+        elif description.isspace() is True:
+            return None
         else:
             creation_time = timezone.now()
+            count_from_date_time = kwargs.get(
+                    'count_from_date_time', creation_time)
+            historical = kwargs.get('historical', False)
+            public = kwargs.get('public', False)
+            running = kwargs.get('running', True)
+            if (historical is True) & (running is False):
+                # A Historical Timer cannot be created non-running,
+                # as this will result in a non-functional timer.
+                # A HT cannot be reset.
+                return None
             new_timer = PADSTimer()
             new_timer.creator_user_id = self.user_id
             new_timer.description = description
-            new_timer.count_from_date_time = kwargs.get(
-                    'count_from_date_time', creation_time)
+            new_timer.count_from_date_time = count_from_date_time
             new_timer.creation_date_time = creation_time
-            new_timer.historical = kwargs.get('historical', False)
+            new_timer.historical = historical
             new_timer.permalink_code = secrets.token_urlsafe(
                     settings['timer_permalink_code_length'])
-            new_timer.public = kwargs.get('public', False)
-            new_timer.running = kwargs.get('running', True)
+            new_timer.public = public
+            new_timer.running = running
             new_timer.save()
             return new_timer.id
     

--- a/padsweb/helpers.py
+++ b/padsweb/helpers.py
@@ -304,6 +304,8 @@ class PADSWriteTimerHelper(PADSWriteHelper):
     def delete(self, timer_id):
         if self.user_is_registered() is False:
             return False
+        elif isinstance(timer_id, int) is False:
+            return False
         else:
             timer_exists = self.timer_model.objects.filter(
                     pk=timer_id).exists()

--- a/padsweb/tests/tests_helpers.py
+++ b/padsweb/tests/tests_helpers.py
@@ -29,6 +29,20 @@ class PADSHelperTests(TestCase):
         # Get Test User id
         cls.user_id = cls.user.id
     
+    def test_get_user_from_db_valid(self):
+        helper = PADSHelper()
+        helper.set_user_id(self.user_id)
+        user_copy = helper.get_user_from_db()
+        self.assertEqual(user_copy.id, self.user.id,
+          'User info in database must be accessible when valid user id is set')
+        
+    def test_get_user_from_db_fake_user(self):
+        user_id = self.user_id_fake
+        helper = PADSHelper(user_id)
+        user_copy = helper.get_user_from_db()
+        self.assertEquals(user_copy, None,
+               'Helper must fail to access User info when invalid User is set')
+    
     def test_set_user_id_valid(self):
         helper = PADSHelper()
         helper.set_user_id(self.user_id)

--- a/padsweb/tests/tests_helpers_timer.py
+++ b/padsweb/tests/tests_helpers_timer.py
@@ -1,0 +1,331 @@
+#
+#
+# Public Archive of Days Since Timers
+# Timer-related Model Helper Unit Tests
+#
+#
+
+from django.test import TestCase
+from django.utils import timezone
+from padsweb.helpers import PADSReadTimerHelper, PADSWriteTimerHelper
+from padsweb.helpers import PADSWriteUserHelper
+from padsweb.models import PADSTimer
+from padsweb.settings import defaults
+
+#
+# Shared Test Items
+#
+write_user_helper = PADSWriteUserHelper()
+#
+# Shared Test Data
+#
+bad_str_inputs = {
+        # Blank and non-string inputs expected to be encountered by PADS
+        # during normal operation
+        'newlines_only_8' : '\n\n\n\n\n\n\n\n',
+        'whitespace_mix' : '\f\n\r\t\v ',
+        'spaces_only_8' : '        ',
+        'tabs_only_8' : '\t\t\t\t\t\t\t\t',
+        'zero_length_string' : '',
+        'none' : None,
+        # The following are expected to be encountered via JSON requests
+        'int' : -9999,
+        'float' : 3.141592654,
+        'list' : [],
+        'tuple' : (),
+        'dict' : {},
+        }
+
+#
+# Retrieval Helper Tests
+class PADSReadTimerHelperGetAllFromDbTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Sign Up Main Test User
+        username_a = 'test-dave'
+        password_a = '    abcdABCD1234'
+        cls.user_a = write_user_helper.prepare_user_in_db(
+                username_a, password_a)
+        cls.user_a.save()
+        
+        # Create Timers for Main Test User
+        write_timer_helper_a = PADSWriteTimerHelper(cls.user_a.id)
+        #  Timer A1: Private
+        cls.timer_a1_desc = 'User A Timer 1 (Private)'
+        write_timer_helper_a.new(cls.timer_a1_desc)
+        #  Timer A2: Public
+        cls.timer_a2_desc = 'User A Timer 2 (Public)'
+        write_timer_helper_a.new(cls.timer_a2_desc, public=True)
+                
+        # Sign Up Second Test User
+        username_b = 'NOT-test-dave'
+        password_b = '    wxyzWXYZ7890'
+        cls.user_b = write_user_helper.prepare_user_in_db(
+                username_b, password_b)
+        cls.user_b.save()
+        
+        # Create Timers for Second Test User
+        write_timer_helper_b = PADSWriteTimerHelper(cls.user_b.id)
+        #  Timer B1: Private
+        cls.timer_b1_desc = 'User B Timer 1 (Private)'
+        write_timer_helper_b.new(cls.timer_b1_desc)
+
+    def test_get_all_from_db(self):
+        read_timer_helper = PADSReadTimerHelper()
+        
+        # Assertion routine
+        def check_timer_access(timer, user):
+            own_private_visible = (timer.creator_user_id == user.id)
+            others_public_visible = (timer.public is True)
+            self.assertTrue( (own_private_visible | others_public_visible),
+             'User must be able to get own private and all public Timers only')                    
+            
+        # Get all timers available to User A and check access
+        read_timer_helper.set_user_id(self.user_a.id)
+        timers_user_a = read_timer_helper.get_all_from_db()
+        #  Assertions
+        for t in timers_user_a:
+            check_timer_access(t, self.user_a)
+            
+        # Get all timers available to User B and check access
+        read_timer_helper.set_user_id(self.user_b.id)
+        timers_user_b = read_timer_helper.get_all_from_db()
+        #  Assertions
+        for t in timers_user_b:
+            check_timer_access(t, self.user_b)
+    
+    def test_get_all_from_db_signed_out(self):
+        read_timer_helper = PADSReadTimerHelper() # No User id set
+        timers = read_timer_helper.get_all_from_db()
+        # Assertions
+        for t in timers:
+            self.assertTrue(t.public,
+              'Helper not assigned to any User must only access public timers')
+    
+
+class PADSReadTimerHelperGetFromDbTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Sign Up Main Test User
+        username_a = 'test-dave'
+        password_a = '    abcdABCD1234'
+        cls.user_a = write_user_helper.prepare_user_in_db(
+                username_a, password_a)
+        cls.user_a.save()
+        
+        # Create Timers for Main Test User
+        write_timer_helper_a = PADSWriteTimerHelper(cls.user_a.id)
+        #  Timer A1: Private
+        cls.timer_a1_desc = 'Test Timer'
+        cls.timer_a1_id = write_timer_helper_a.new(cls.timer_a1_desc)
+        #  Timer A2: Public
+        cls.timer_a2_desc = cls.timer_a1_desc
+        cls.timer_a2_id = write_timer_helper_a.new(
+                cls.timer_a2_desc, public=True)
+
+        # Sign Up Second Test User
+        username_b = 'NOT-test-dave'
+        password_b = '    wxyzWXYZ7890'
+        cls.user_b = write_user_helper.prepare_user_in_db(
+                username_b, password_b)
+        cls.user_b.save()
+        
+        # Create Timers for Second Test User
+        write_timer_helper_b = PADSWriteTimerHelper(cls.user_b.id)
+        #  Timer B1: Private
+        cls.timer_b1_desc = cls.timer_a1_desc
+        cls.timer_b1_id = write_timer_helper_b.new(cls.timer_b1_desc)
+
+    def test_get_from_db_valid_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        timer = read_timer_helper.get_from_db(self.timer_a1_id)
+        # Assertions
+        self.assertEqual(timer.id, self.timer_a1_id, 
+                         'User A must get a Timer of a matching id')
+    
+    def test_get_from_db_valid_b(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_b.id)
+        timer = read_timer_helper.get_from_db(self.timer_b1_id)
+        # Assertions
+        self.assertEqual(timer.id, self.timer_b1_id, 
+                         'User B must get a Timer of a matching id')
+
+    def test_get_from_db_valid_public(self):
+        read_timer_helper = PADSReadTimerHelper()
+        timer = read_timer_helper.get_from_db(self.timer_a2_id)
+        # Assertions
+        self.assertEqual(timer.id, self.timer_a2_id, 
+                   'User not signed in must get a public Timer of matching id')
+
+    def test_get_from_db_wrong_user_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        timer = read_timer_helper.get_from_db(self.timer_b1_id)
+        # Assertions
+        self.assertIsNone(timer, 'User A must not get another User\'s Timers')
+    
+    def test_get_from_db_wrong_user_b(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_b.id)
+        timer = read_timer_helper.get_from_db(self.timer_a1_id)
+        # Assertions
+        self.assertIsNone(timer, 'User B must not get another User\'s Timers')
+    
+    def test_get_from_db_wrong_user_signed_out(self):
+        read_timer_helper = PADSReadTimerHelper()
+        timer = read_timer_helper.get_from_db(self.timer_a1_id)
+        # Assertions
+        self.assertIsNone(timer, 
+                'User not signed in must not be able to access private Timers')
+
+    def test_get_from_db_invalid_id_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        timer = read_timer_helper.get_from_db(-9999)
+        # Assertions
+        self.assertIsNone(timer, 
+                    'User A must not get any Timer without a valid Timer id')
+
+    def test_get_from_db_invalid_id_s(self):
+        read_timer_helper = PADSReadTimerHelper()
+        timer = read_timer_helper.get_from_db(-9999)
+        # Assertions
+        self.assertIsNone(timer, 
+          'User not signed in must not get any Timer without a valid Timer id')
+
+
+class PADSReadTimerHelperGetByPermalinkCodeTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        
+        def new_timer_get_permalink(user_id, description, **kwargs):
+            write_timer_helper = PADSWriteTimerHelper(user_id)
+            timer_id = write_timer_helper.new(user_id, **kwargs)
+            timer = PADSTimer.objects.get(pk=timer_id)
+            return timer.permalink_code
+            
+        # Sign Up Main Test User
+        username_a = 'test-dave'
+        password_a = '    abcdABCD1234'
+        cls.user_a = write_user_helper.prepare_user_in_db(
+                username_a, password_a)
+        cls.user_a.save()
+        
+        # Create Timers for Main Test User
+        #  Timer A1: Private
+        cls.timer_a1_desc = 'Test Timer'
+        cls.timer_a1_plink = new_timer_get_permalink(
+                cls.user_a.id, cls.timer_a1_desc)
+        #  Timer A2: Public
+        cls.timer_a2_desc = cls.timer_a1_desc
+        cls.timer_a2_plink = new_timer_get_permalink(
+                cls.user_a.id, cls.timer_a2_desc, public=True)
+
+        # Sign Up Second Test User
+        username_b = 'NOT-test-dave'
+        password_b = '    wxyzWXYZ7890'
+        cls.user_b = write_user_helper.prepare_user_in_db(
+                username_b, password_b)
+        cls.user_b.save()
+        
+        # Create Timers for Second Test User
+        #  Timer B1: Private
+        cls.timer_b1_desc = cls.timer_a1_desc
+        cls.timer_b1_plink = new_timer_get_permalink(
+                cls.user_b.id, cls.timer_b1_desc)
+
+    def test_get_from_db_by_permalink_code_valid_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_a1_plink)
+        # Assertions
+        self.assertEqual(timer.permalink_code, self.timer_a1_plink, 
+                        'User A must get a Timer of a matching permalink code')
+    
+    def test_get_from_db_by_permalink_code_valid_b(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_b.id)
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_b1_plink)
+        # Assertions
+        self.assertEqual(timer.permalink_code, self.timer_b1_plink, 
+                        'User B must get a Timer of a matching permalink code')
+
+    def test_get_from_db_by_permalink_code_valid_signed_out(self):
+        read_timer_helper = PADSReadTimerHelper()
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_a2_plink)
+        # Assertions
+        self.assertEqual(timer.permalink_code, self.timer_a2_plink, 
+            'User not signed in must get a public Timer of matching permalink')
+
+    def test_get_from_db_by_permalink_code_wrong_user_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_b1_plink)
+        # Assertions
+        self.assertIsNone(timer, 'User A must not get another User\'s Timers')
+    
+    def test_get_from_db_by_permalink_code_wrong_user_b(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_b.id)
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_a1_plink)
+        # Assertions
+        self.assertIsNone(timer, 'User B must not get another User\'s Timers')
+    
+    def test_get_from_db_by_permalink_code_wrong_user_signed_out(self):
+        read_timer_helper = PADSReadTimerHelper()
+        timer = read_timer_helper.get_from_db_by_permalink_code(
+                self.timer_a1_plink)
+        # Assertions
+        self.assertIsNone(timer, 
+                'User not signed in must not be able to access private Timers')
+
+    def test_get_from_db_by_permalink_code_invalid_id_a(self):
+        read_timer_helper = PADSReadTimerHelper(self.user_a.id)
+        for b in bad_str_inputs:
+            timer = read_timer_helper.get_from_db_by_permalink_code(b)
+            # Assertions
+            self.assertIsNone(timer, 
+                       'User A must not get any Timer without valid permalink')
+
+    def test_get_from_db_by_permalink_code_invalid_id_signed_out(self):
+        read_timer_helper = PADSReadTimerHelper()
+        for b in bad_str_inputs:
+            timer = read_timer_helper.get_from_db_by_permalink_code(b)
+            # Assertions
+            self.assertIsNone(timer, 
+               'User not signed in musn\'t get Timers without valid permalink')
+
+class PADSReadTimerGetGroupsByTimerIdTests(TestCase):
+    def setUpTestData(self):
+        raise NotImplementedError
+        
+    def test_get_groups_by_timer_id_valid_a(self):
+        raise NotImplementedError
+
+    def test_get_groups_by_timer_id_valid_b(self):
+        raise NotImplementedError
+
+    def test_get_groups_by_timer_id_valid_public(self):
+        raise NotImplementedError
+        
+    def test_get_groups_by_timer_id_wrong_user_a(self):
+        raise NotImplementedError
+    
+    def test_get_groups_by_timer_id_invalid_id(self):
+        raise NotImplementedError
+    
+
+class PADSReadTimerGetResetsByTimerIdTests(TestCase):
+# TODO: PADSReadTimerHelper.get_resets_by_timer_id() (valid, wrong user, not signed in)
+    def setUpTestData(self):
+        raise NotImplementedError
+    
+    
+
+#
+# Write Helper Tests
+#
+# TODO: PADSWriteTimerHelper.new() (valid, not signed in, bad input)
+# TODO: PADSWriteTimerHelper.delete() (valid, not signed in, wrong user, bad input)
+# TODO: PADSWriteTimerHelper.set_description() (valid, not signed in, wrong user, bad input)
+# TODO: PADSWriteTimerHelper.stop_by_id() (valid, not signed in, wrong user, bad input)
+# TODO: PADSWriteTimerHelper.restart_by_id() (valid, not signed in, wrong user, bad input)
+

--- a/padsweb/tests/tests_helpers_timer.py
+++ b/padsweb/tests/tests_helpers_timer.py
@@ -1272,7 +1272,23 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                     'Count-from date times of all Test Timers must not change')
     
     def test_reset_by_id_historical(self):
-        raise NotImplementedError
+        timer_q2_ph_desc = 'Test Timer Q2 by QL User (Pub/Historical)'
+        reset_reason = 'Test QL User attempting to reset historical Timer'
+        timer_q2_id = self.write_timer_helper_q.new(
+                timer_q2_ph_desc, historical=True)
+        timer_q2 = PADSTimer.objects.get(pk=timer_q2_id)
+        timer_reset = self.write_timer_helper_q.reset_by_id(
+                timer_q2_id, reset_reason)
+        orig_count_time_q2 = timer_q2.count_from_date_time
+        timer_q2_rel = PADSTimer.objects.get(pk=timer_q2_id) # Reload
+        log_entry_count = PADSTimerReset.objects.filter(
+                reason__icontains=reset_reason).count()
+        # Assertions
+        self.assertFalse(timer_reset)
+        self.assertEquals(timer_q2_rel.count_from_date_time,
+                          orig_count_time_q2)
+        self.assertEquals(log_entry_count, 0,
+                        'Failed Timer resets must not be logged')
 
     def test_reset_by_id_invalid_id(self):
         reset_reason = 'Test User A resetting non-existent Timer'

--- a/padsweb/tests/tests_helpers_timer.py
+++ b/padsweb/tests/tests_helpers_timer.py
@@ -1236,30 +1236,29 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
         reset_reason = 'Test User Q Resetting Timer A1'
         timer_reset = self.write_timer_helper_q.reset_by_id(
                 self.timer_a1_p_id, reset_reason)
-        log_entry_count = PADSTimerReset.objects.filter(
-                reason__icontains=reset_reason).count()
+        reset_logged = PADSTimerReset.objects.filter(
+                timer_id=self.timer_a1_p_id,
+                reason__icontains=reset_reason).exists()
         # Assertions
         self.assertFalse(timer_reset,
                   'Helper must indicate failure to reset other Users\' Timers')
         self.assertTrue(self.timers_cfdts_unchanged(),
                     'Count-from date times of all Test Timers must not change')
-        self.assertEquals(log_entry_count, 0,
-                        'Failed Timer reset must not be logged')
+        self.assertFalse(reset_logged, 'Failed Timer reset must not be logged')
         
     def test_reset_by_id_signed_out(self):
         write_timer_helper = PADSWriteTimerHelper()
         reset_reason = 'Signed Out User Resetting Timer A1'
         timer_reset = write_timer_helper.reset_by_id(
                 self.timer_a1_p_id, reset_reason)
-        log_entry_count = PADSTimerReset.objects.filter(
-                reason__icontains=reset_reason).count()
+        reset_logged = PADSTimerReset.objects.filter(
+                reason__icontains=reset_reason).exists()
         # Assertions
         self.assertFalse(timer_reset,
                         'Helper must indicate failure to reset Timer')
         self.assertTrue(self.timers_cfdts_unchanged(),
                     'Count-from date times of all Test Timers must not change')
-        self.assertEquals(log_entry_count, 0,
-                        'Failed Timer reset must not be logged')
+        self.assertFalse(reset_logged, 'Failed Timer reset must not be logged')
 
     def test_reset_by_id_bad_reason_a(self):
         # First-stage Assertions
@@ -1283,14 +1282,13 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                 timer_q2_id, reset_reason)
         orig_count_time_q2 = timer_q2.count_from_date_time
         timer_q2_rel = PADSTimer.objects.get(pk=timer_q2_id) # Reload
-        log_entry_count = PADSTimerReset.objects.filter(
-                reason__icontains=reset_reason).count()
+        reset_logged = PADSTimerReset.objects.filter(
+                timer_id=timer_q2_id, reason__icontains=reset_reason).exists()
         # Assertions
         self.assertFalse(timer_reset)
         self.assertEquals(timer_q2_rel.count_from_date_time,
                           orig_count_time_q2)
-        self.assertEquals(log_entry_count, 0,
-                        'Failed Timer resets must not be logged')
+        self.assertFalse(reset_logged,'Failed Timer resets must not be logged')
 
     def test_reset_by_id_invalid_id(self):
         reset_reason = 'Test User A resetting non-existent Timer'
@@ -1300,13 +1298,13 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                     i, reset_reason)
             self.assertFalse(timer_reset,
                      'Helper must indicate failed reset with invalid Timer id')
-        log_entry_count = PADSTimerReset.objects.filter(
-                reason__icontains=reset_reason).count()
+        reset_logged = PADSTimerReset.objects.filter(
+                reason__icontains=reset_reason).exists()
         # Second-stage Assertions
         self.assertTrue(self.timers_cfdts_unchanged(),
                     'Count-from date times of all Test Timers must not change')
-        self.assertEquals(log_entry_count, 0,
-                        'Failed Timer resets must not be logged')
+        self.assertFalse(reset_logged, 
+                         'Failed Timer resets must not be logged')
 
 class PADSWriteTimerHelperStopByIdTests(TestCase):
     @classmethod

--- a/padsweb/tests/tests_helpers_timer.py
+++ b/padsweb/tests/tests_helpers_timer.py
@@ -1153,7 +1153,23 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                 timer_q1_p_desc, public=True)
         cls.timer_q1_p = PADSTimer.objects.get(pk=cls.timer_q1_p_id)
         cls.orig_count_time_q1_p = cls.timer_q1_p.count_from_date_time
-            
+    
+    def timers_cfdts_unchanged(self):
+        '''Returns True if the count-from date times of all Test Timers in the 
+        Timer Write Helper Set Description Test Case have remained unchanged.
+        '''
+        timer_rel_a1 = PADSTimer.objects.get(pk=self.timer_a1_p_id)
+        timer_a_cfdt_same = (
+                self.orig_count_time_a1_p == timer_rel_a1.count_from_date_time)
+        timer_rel_b1 = PADSTimer.objects.get(pk=self.timer_b1_p_id)
+        timer_b_cfdt_same = (
+             self.orig_count_time_b1_p == timer_rel_b1.count_from_date_time)
+        timer_rel_q1 = PADSTimer.objects.get(pk=self.timer_q1_p_id)
+        timer_q_cfdt_same = (
+             self.orig_count_time_q1_p == timer_rel_q1.count_from_date_time)
+        return (timer_a_cfdt_same & timer_b_cfdt_same & timer_q_cfdt_same)
+
+    
     def test_reset_by_id_valid_a(self):
         reset_reason = 'Test User A Resetting Timer A1'
         timer_reset = self.write_timer_helper_a.reset_by_id(
@@ -1219,50 +1235,28 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
         reset_reason = 'Test User Q Resetting Timer A1'
         timer_reset = self.write_timer_helper_q.reset_by_id(
                 self.timer_a1_p_id, reset_reason)
-        # Reload Timers
-        timer_a1_p_rel = PADSTimer.objects.get(pk=self.timer_a1_p_id)
-        count_time_a = timer_a1_p_rel.count_from_date_time
-        timer_b1_p_rel = PADSTimer.objects.get(pk=self.timer_b1_p_id)
-        count_time_b = timer_b1_p_rel.count_from_date_time
-        timer_q1_p_rel = PADSTimer.objects.get(pk=self.timer_q1_p_id)
-        count_time_q = timer_q1_p_rel.count_from_date_time
         log_entry_count = PADSTimerReset.objects.filter(
                 reason__icontains=reset_reason).count()
         # Assertions
         self.assertFalse(timer_reset,
                   'Helper must indicate failure to reset other Users\' Timers')
-        self.assertEquals(count_time_a, self.orig_count_time_a1_p,
-                          'Timer A1 count-from date time must remain the same')
-        self.assertEquals(count_time_b, self.orig_count_time_b1_p,
-                          'Timer B1 count-from date time must remain the same')
-        self.assertEquals(count_time_q, self.orig_count_time_q1_p,
-                          'Timer Q1 count-from date time must remain the same')
+        self.assertTrue(self.timers_cfdts_unchanged(),
+                    'Count-from date times of all Test Timers must not change')
         self.assertEquals(log_entry_count, 0,
-                          'Failed Timer reset must not be logged')
-    
+                        'Failed Timer reset must not be logged')
+        
     def test_reset_by_id_signed_out(self):
         write_timer_helper = PADSWriteTimerHelper()
         reset_reason = 'Signed Out User Resetting Timer A1'
         timer_reset = write_timer_helper.reset_by_id(
                 self.timer_a1_p_id, reset_reason)
-        # Reload Timers
-        timer_a1_p_rel = PADSTimer.objects.get(pk=self.timer_a1_p_id)
-        count_time_a = timer_a1_p_rel.count_from_date_time
-        timer_b1_p_rel = PADSTimer.objects.get(pk=self.timer_b1_p_id)
-        count_time_b = timer_b1_p_rel.count_from_date_time
-        timer_q1_p_rel = PADSTimer.objects.get(pk=self.timer_q1_p_id)
-        count_time_q = timer_q1_p_rel.count_from_date_time
         log_entry_count = PADSTimerReset.objects.filter(
                 reason__icontains=reset_reason).count()
         # Assertions
         self.assertFalse(timer_reset,
                         'Helper must indicate failure to reset Timer')
-        self.assertEquals(count_time_a, self.orig_count_time_a1_p,
-                          'Timer A1 count-from date time must remain the same')
-        self.assertEquals(count_time_b, self.orig_count_time_b1_p,
-                          'Timer B1 count-from date time must remain the same')
-        self.assertEquals(count_time_q, self.orig_count_time_q1_p,
-                          'Timer Q1 count-from date time must remain the same')
+        self.assertTrue(self.timers_cfdts_unchanged(),
+                    'Count-from date times of all Test Timers must not change')
         self.assertEquals(log_entry_count, 0,
                         'Failed Timer reset must not be logged')
 
@@ -1273,20 +1267,12 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                     self.timer_a1_p_id, i)
             self.assertFalse(timer_reset,
                  'Helper must indicate failed Timer reset with invalid reason')
-        # Reload Timers
-        timer_a1_p_rel = PADSTimer.objects.get(pk=self.timer_a1_p_id)
-        count_time_a = timer_a1_p_rel.count_from_date_time
-        timer_b1_p_rel = PADSTimer.objects.get(pk=self.timer_b1_p_id)
-        count_time_b = timer_b1_p_rel.count_from_date_time
-        timer_q1_p_rel = PADSTimer.objects.get(pk=self.timer_q1_p_id)
-        count_time_q = timer_q1_p_rel.count_from_date_time
         # Second-stage Assertions
-        self.assertEquals(count_time_a, self.orig_count_time_a1_p,
-                          'Timer A1 count-from date time must remain the same')
-        self.assertEquals(count_time_b, self.orig_count_time_b1_p,
-                          'Timer B1 count-from date time must remain the same')
-        self.assertEquals(count_time_q, self.orig_count_time_q1_p,
-                          'Timer Q1 count-from date time must remain the same')
+        self.assertTrue(self.timers_cfdts_unchanged(),
+                    'Count-from date times of all Test Timers must not change')
+    
+    def test_reset_by_id_historical(self):
+        raise NotImplementedError
 
     def test_reset_by_id_invalid_id(self):
         reset_reason = 'Test User A resetting non-existent Timer'
@@ -1296,22 +1282,11 @@ class PADSWriteTimerHelperResetByIdTests(TestCase):
                     i, reset_reason)
             self.assertFalse(timer_reset,
                      'Helper must indicate failed reset with invalid Timer id')
-        # Reload Timers
-        timer_a1_p_rel = PADSTimer.objects.get(pk=self.timer_a1_p_id)
-        count_time_a = timer_a1_p_rel.count_from_date_time
-        timer_b1_p_rel = PADSTimer.objects.get(pk=self.timer_b1_p_id)
-        count_time_b = timer_b1_p_rel.count_from_date_time
-        timer_q1_p_rel = PADSTimer.objects.get(pk=self.timer_q1_p_id)
-        count_time_q = timer_q1_p_rel.count_from_date_time
         log_entry_count = PADSTimerReset.objects.filter(
                 reason__icontains=reset_reason).count()
         # Second-stage Assertions
-        self.assertEquals(count_time_a, self.orig_count_time_a1_p,
-                          'Timer A1 count-from date time must remain the same')
-        self.assertEquals(count_time_b, self.orig_count_time_b1_p,
-                          'Timer B1 count-from date time must remain the same')
-        self.assertEquals(count_time_q, self.orig_count_time_q1_p,
-                          'Timer Q1 count-from date time must remain the same')
+        self.assertTrue(self.timers_cfdts_unchanged(),
+                    'Count-from date times of all Test Timers must not change')
         self.assertEquals(log_entry_count, 0,
                         'Failed Timer resets must not be logged')
 

--- a/padsweb/tests/tests_helpers_user.py
+++ b/padsweb/tests/tests_helpers_user.py
@@ -390,7 +390,8 @@ class PADSWriteUserHelperSetTimezoneTests(TestCase):
         result = write_user_helper_stz.set_time_zone(tz_name)
         ql_user = PADSUser.objects.get(pk=self.ql_user_id) # Reload User
         # Assertion
-        self.assertTrue(result)
+        self.assertTrue(result,
+                        'Helper must indicate success in timezone change')
         self.assertEquals(ql_user.time_zone, tz_name, 
                           'User must be able to switch to a valid timezone')
     
@@ -401,7 +402,8 @@ class PADSWriteUserHelperSetTimezoneTests(TestCase):
         result = write_user_helper_stz.set_time_zone(tz_name)
         # Assertions
         ql_user = PADSUser.objects.get(pk=self.ql_user_id) # Reload User
-        self.assertFalse(result)
+        self.assertFalse(result,
+                         'Helper must indicate failure to change timezone')
         self.assertNotEquals(ql_user.time_zone, tz_name, 
                           'User must fail to switch to an invalid timezone')
         self.assertEquals(ql_user.time_zone, tz_name_orig,
@@ -414,7 +416,8 @@ class PADSWriteUserHelperSetTimezoneTests(TestCase):
         for i in blank_inputs:
             result = write_user_helper_stz.set_time_zone(i)
             user = PADSUser.objects.get(pk=self.ql_user_id) # Reload User
-            self.assertFalse(result)
+            self.assertFalse(result, 
+                             'Helper must indicate failure to change timezone')
             self.assertNotEquals(user.time_zone, i, 
                           'User must fail to switch to an invalid timezone')
             self.assertEquals(user.time_zone, tz_name_orig,

--- a/padsweb/tests/tests_helpers_user.py
+++ b/padsweb/tests/tests_helpers_user.py
@@ -222,7 +222,7 @@ class PADSWriteUserHelperNewTests(TestCase):
         ql_user_id = self.read_user_helper.split_ql_password(ql_password)[0]
         # Assertions
         ql_user_test = PADSUser.objects.get(pk=ql_user_id)
-        self.assertEquals(str(ql_user_test.id), ql_user_id,
+        self.assertEquals(ql_user_test.id, ql_user_id,
           'Quick List user must be in database with correct id after creation')
     
     def test_new_blank_usernames(self):


### PR DESCRIPTION
This is a continuation of the work in progress merged in #8. The previous merge only added User Read Helper unit tests. More unit tests, this time for the rewritten User Write Timer Helpers, are added in this pull request among implementation corrections to both User and Timer Helpers, as well as User Helper tests.